### PR TITLE
Always set a correct temppath / use tox for testing

### DIFF
--- a/mangopaysdk/configuration.py
+++ b/mangopaysdk/configuration.py
@@ -1,5 +1,6 @@
 from mangopaysdk.tools import enums
 import logging
+import tempfile
 
 
 class Configuration:
@@ -15,7 +16,7 @@ class Configuration:
     BaseUrl = 'https://api.sandbox.mangopay.com'
 
     # path to temp - required to cache auth tokens
-    TempPath = "c:\Temp\\"
+    TempPath = tempfile.tempdir or "c:\Temp"
 
     # Constant to switch debug mode (0/1) - display all request and response data
     DebugMode = 0

--- a/mangopaysdk/tools/storages/defaultstoragestrategy.py
+++ b/mangopaysdk/tools/storages/defaultstoragestrategy.py
@@ -14,7 +14,7 @@ class DefaultStorageStrategy(IStorageStrategy):
         """Gets the currently stored objects as dictionary.
         return stored Token dictionary or null.
         """
-        DefaultStorageStrategy.cache_path = Configuration.TempPath + "cached-data.py"
+        DefaultStorageStrategy.cache_path = os.path.join(Configuration.TempPath, "cached-data.py")
 
         if not os.path.exists(DefaultStorageStrategy.cache_path):
            return None
@@ -39,7 +39,7 @@ class DefaultStorageStrategy(IStorageStrategy):
         """Stores authorization token passed as an argument.
         param obj instance to be stored.
         """
-        DefaultStorageStrategy.cache_path = Configuration.TempPath + "cached-data.py"
+        DefaultStorageStrategy.cache_path = os.path.join(Configuration.TempPath, "cached-data.py")
 
         if obj == None: 
             return

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pytest]
+python_files=test*.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py27,py34
+
+[testenv]
+whitelist_externals=
+    rm
+commands =
+    py.test tests/
+deps =
+    requests
+    pytest
+


### PR DESCRIPTION
TempPath is set using the tempfile module so you always get a default valid path

Also I added a tox configuration so contributors can easily collect and run tests using py.test

See https://testrun.org/tox/latest/ and http://pytest.org/latest/contents.html