### PR TITLE
Make tempfile return a dir path

### DIFF
--- a/mangopaysdk/configuration.py
+++ b/mangopaysdk/configuration.py
@@ -16,7 +16,7 @@ class Configuration:
     BaseUrl = 'https://api.sandbox.mangopay.com'
 
     # path to temp - required to cache auth tokens
-    TempPath = tempfile.tempdir or "c:\Temp"
+    TempPath = tempfile.mkdtemp() or "c:\Temp"
 
     # Constant to switch debug mode (0/1) - display all request and response data
     DebugMode = 0


### PR DESCRIPTION
On Linux, tempfile.tempdir is empty and the Windows style hard coded dir path takes precedence, which does not work on Linux. Replaced with using tempfile.mkdtemp() instead.