### PR TITLE
Make "develop" sub command available for setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 # to build - python setup.py sdist upload
 setup(
@@ -15,5 +15,5 @@ setup(
         "requests-oauthlib>=0.4.0",
         "lockfile>=0.9.1"
     ],
-	keywords="leetchi api sdk mangopay"
+    keywords="leetchi api sdk mangopay"
 )


### PR DESCRIPTION
In development it is often desirable to be able to install a package so that you can edit its source while working on a project. The "develop" sub command for setup.py accomplishes this: "python setup.py develop". setuptools is needed for this, instead of distutils.core