### PR TITLE
Create a `Configuration.Session` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ You should find that file in `Python_installation_folder\Lib\site-packages\reque
 	sdk.Config.SSLVerification = 'C:\\Python27\\Lib\\site-packages\\requests\\cacert.pem'
 
 
+Connection pooling
+-------------------------------------------------
+To benefit from HTTP connection reuse you need to set `api.Config.Session` like this:
+
+    import requests
+    api.Config.Session = requests.Session()
+
+WARNING: sessions are not guaranteed to be thread-safe!
+
+See the upstream [Session Objects](http://docs.python-requests.org/en/master/user/advanced/#session-objects) documentation for more details.
+
+
 Sample usage
 -------------------------------------------------
 

--- a/mangopaysdk/configuration.py
+++ b/mangopaysdk/configuration.py
@@ -28,6 +28,9 @@ class Configuration:
     # NB: you can swap this class for one of ours that implement some custom logic
     RestToolClass = None
 
+    # Session object from the `requests` library
+    Session = None
+
 
 # we use DEBUG level for internal debugging
 if (Configuration.DebugMode):

--- a/mangopaysdk/tools/resttool.py
+++ b/mangopaysdk/tools/resttool.py
@@ -41,6 +41,7 @@ class BaseRestTool(object):
         self._root = root
         self._debugMode = self._root.Config.DebugMode
         self._sslVerification = self._root.Config.SSLVerification
+        self._session = self._root.Config.Session
 
     def Request(self, urlMethod, requestType, requestData = None, pagination = None, additionalUrlParams = None):
         """Call request to MangoPay API.
@@ -107,7 +108,7 @@ class BaseRestTool(object):
     def _sendRequest(self, request):
         """Prepare and send the request"""
         prepared_request = request.prepare()
-        session = requests.Session()
+        session = self._session or requests.Session()
         response = session.send(prepared_request, verify=self._sslVerification)
         return response
 


### PR DESCRIPTION
This partially fixes #48 by allowing developers to benefit from connection reuse (at the expense of thread safety).