### PR TITLE
Stop closing the connection after a non-GET request

### DIFF
--- a/mangopaysdk/tools/resttool.py
+++ b/mangopaysdk/tools/resttool.py
@@ -85,12 +85,12 @@ class BaseRestTool(object):
 
         authObj = AuthenticationHelper(self._root).GetRequestAuthObject(self._authRequired)
 
-        headers = {"Content-Type" : "application/x-www-form-urlencoded", 'Connection':'close'}
+        headers = {"Content-Type" : "application/x-www-form-urlencoded"}
 
         if (idempotencyKey != None):
-            headersJson = {"Content-Type" : "application/json", 'Connection':'close', "Idempotency-Key" : idempotencyKey}
+            headersJson = {"Content-Type" : "application/json", "Idempotency-Key" : idempotencyKey}
         else:
-            headersJson = {"Content-Type" : "application/json", 'Connection':'close'}
+            headersJson = {"Content-Type" : "application/json"}
 
         if (self._debugMode): logging.getLogger(__name__).debug('REQUEST: {0} {1}\n  DATA: {2}'.format(self._requestType, fullUrl, self._requestData))
 


### PR DESCRIPTION
The `Connection: close` header is thwarting the mechanism for connection reuse introduced in #49 to fix #48. I've tested this in production earlier, our weekly payday only used one connection and was a lot faster.