### PR TITLE
DirectPayIn missing SecureModeNeeded property

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -1,0 +1,1 @@
+This SDK is a client library for interacting with the Mangopay API.

--- a/mangopay/resources.py
+++ b/mangopay/resources.py
@@ -354,6 +354,7 @@ class DirectPayIn(PayIn):
     secure_mode_redirect_url = CharField(api_name='SecureModeRedirectURL')
     secure_mode_return_url = CharField(api_name='SecureModeReturnURL')
     card = ForeignKeyField(Card, api_name='CardId', required=True)
+    secure_mode_needed = BooleanField(api_name='SecureModeNeeded')
     secure_mode = CharField(api_name='SecureMode',
                             choices=constants.SECURE_MODE_CHOICES,
                             default=constants.SECURE_MODE_CHOICES.default)

--- a/tests/test_payins.py
+++ b/tests/test_payins.py
@@ -143,6 +143,7 @@ class PayInsTest(BaseTest):
         direct_payin.save()
         self.assertIsInstance(direct_payin, DirectPayIn)
         self.assertEqual(direct_payin.status, 'SUCCEEDED')
+        self.assertEqual(direct_payin.secure_mode_needed, False)
 
         self.assertEqual(direct_payin.secure_mode_return_url, None)
         direct_payin_params.pop('secure_mode_return_url')


### PR DESCRIPTION
Hi, 

Here is a fix which add the missing property into DirectPayIn class and a check into unit test.

see my issue #74 

and this issue in the deprecated SDK version #63 

It also add `DESCRIPTION.md` file which is needed to `tox`.

Thanks