### PR TITLE
Inherited properties serialization bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ tests/credentials.py
 .vscode
 
 local_examples/
+credited_user_id.py

--- a/mangopay/base.py
+++ b/mangopay/base.py
@@ -2,7 +2,7 @@ import six
 
 from copy import deepcopy
 
-from .fields import PrimaryKeyField, FieldDescriptor, Field
+from .fields import PrimaryKeyField, FieldDescriptor, Field, ForeignRelatedObject
 from .query import UpdateQuery, InsertQuery, SelectQuery
 from .signals import pre_save, post_save
 from .utils import force_text, force_str
@@ -104,6 +104,8 @@ class ApiObjectBase(type):
                     meta_options[k] = v
 
             for (k, attr) in b.__dict__.items():
+                if isinstance(attr, ForeignRelatedObject) and isinstance(getattr(attr, 'old_field'), Field):
+                    attrs[k] = deepcopy(getattr(attr, 'old_field'))
                 if not isinstance(attr, FieldDescriptor) or attr in attrs:
                     continue
 

--- a/mangopay/fields.py
+++ b/mangopay/fields.py
@@ -404,10 +404,11 @@ class OneToOneField(ForeignKeyField):
 
 
 class ForeignRelatedObject(object):
-    def __init__(self, to, name):
+    def __init__(self, to, name, old_field):
         self.field_name = name
         self.to = to
         self.cache_name = '_cache_%s' % name
+        self.old_field = old_field
 
     def __get__(self, instance, instance_type=None):
         if not getattr(instance, self.cache_name, None):

--- a/mangopay/fields.py
+++ b/mangopay/fields.py
@@ -366,7 +366,7 @@ class ForeignKeyField(CharField):
             self.related_name = klass._meta.verbose_name + '_set'
 
         klass._meta.rel_fields[name] = self.name
-        setattr(klass, self.descriptor, ForeignRelatedObject(self.to, self.name))
+        setattr(klass, self.descriptor, ForeignRelatedObject(self.to, self.name, getattr(klass, self.descriptor)))
         setattr(klass, self.name, None)
 
         reverse_rel = ReverseForeignRelatedObject(klass, self.name)

--- a/mangopay/resources.py
+++ b/mangopay/resources.py
@@ -381,7 +381,7 @@ class DirectPayIn(PayIn):
     author = ForeignKeyField(User, api_name='AuthorId', required=True)
     credited_wallet = ForeignKeyField(Wallet, api_name='CreditedWalletId', required=True)
     secure_mode_redirect_url = CharField(api_name='SecureModeRedirectURL')
-    secure_mode_return_url = CharField(api_name='SecureModeReturnURL')
+    secure_mode_return_url = CharField(api_name='SecureModeReturnURL', required=True)
     card = ForeignKeyField(Card, api_name='CardId', required=True)
     secure_mode_needed = BooleanField(api_name='SecureModeNeeded')
     secure_mode = CharField(api_name='SecureMode',

--- a/mangopay/resources.py
+++ b/mangopay/resources.py
@@ -343,7 +343,7 @@ class Mandate(BaseModel):
 
 
 class PayIn(BaseModel):
-    credited_user = ForeignKeyField(User, api_name='CreditedUserId', required=True, related_name='credited_users')
+    credited_user = ForeignKeyField(User, api_name='CreditedUserId', related_name='credited_users')
     credited_funds = MoneyField(api_name='CreditedFunds')
     credited_wallet = ForeignKeyField(Wallet, api_name='CreditedWalletId', required=True)
     debited_wallet = ForeignKeyField(Wallet, api_name='DebitedWalletId')


### PR DESCRIPTION
After fixing this issue, a problem was revealed by [this Travis build job](https://travis-ci.org/Mangopay/mangopay2-python-sdk/jobs/228103949):

Having the field correctly populated, we got a lot of errors because the field is **required** in `PayIn` root entity, but not present into the model when [defined in the test](https://github.com/Mangopay/mangopay2-python-sdk/blob/master/tests/test_transfers.py#L157):

```python
        direct_payin_params = {
            "author": self.card.user,
            "debited_funds": Money(amount=10000, currency='EUR'),
            "fees": Money(amount=100, currency='EUR'),
            "credited_wallet": wallet,
            "card": self.card,
            "secure_mode": "DEFAULT",
            "secure_mode_return_url": "http://www.ulule.com/"
        }
        direct_payin = DirectPayIn(**direct_payin_params)
        direct_payin.save()
```

so when trying to `direct_payin.save()` it throws: `ValueError: Missing mandatory field: credited_user_id`

I [removed ](https://github.com/Mangopay/mangopay2-python-sdk/compare/bugfix/inherited-properties-serialize-bug?expand=1#diff-dc10e366a9686f9143165ebd682c0015) the `required=True` instruction from the `PayIn.credited_user` which is also in concordance [with the docs](https://docs.mangopay.com/endpoints/v2.01/payins#e278_create-a-card-direct-payin) that are marking this field as optional.

After this improvement we enhance the PayIn and other entities creation as referenced in #105 

```python
params = {
   # as User object
    "credited_user": natural_user,
   # or as string value of the id
    "credited_user_id": natural_user.get_pk()
}
```