### PR TITLE
Addresses issue #93

### DIFF
--- a/mangopay/fields.py
+++ b/mangopay/fields.py
@@ -296,8 +296,8 @@ class RefundReasonField(Field):
     def python_value(self, value):
         if value is not None:
             return Reason(
-                type=value.get('RefundReasonType') or value['RefusedReasonType'],
-                message=value.get('RefundReasonMessage') or value['RefusedReasonMessage']
+                type=value.get('RefundReasonType'),
+                message=value.get('RefundReasonMessage')
             )
 
         return value


### PR DESCRIPTION
The API returns responses with null values for RefundReasonMessage when creating a Refund (only tested with PayInRefund), causing a KeyError here.

See issue #93 