### PR TITLE
Bugfix/list inherited objects properties

### DIFF
--- a/mangopay/query.py
+++ b/mangopay/query.py
@@ -88,7 +88,7 @@ class SelectQuery(BaseQuery):
 
         for entry in data:
             model_klass = cast(entry)
-            results.append(model_klass(handler=handler, **dict(self.parse_result(entry))))
+            results.append(model_klass(handler=handler, **dict(self.parse_result(entry, model_klass))))
 
         return results
 

--- a/tests/fixtures/user_list_full.json
+++ b/tests/fixtures/user_list_full.json
@@ -5,7 +5,8 @@
         "Id": "1167495",
         "Tag": null,
         "CreationDate": 1382605938,
-        "KYCLevel": "LIGHT"
+        "KYCLevel": "LIGHT",
+        "FirstName": "Arnaud"
     },
     {
         "PersonType": "LEGAL",
@@ -13,7 +14,8 @@
         "Id": "1167496",
         "Tag": null,
         "CreationDate": 1382607639,
-        "KYCLevel": "LIGHT"
+        "KYCLevel": "LIGHT",
+        "Name": "MMDP United"
     },
     {
         "PersonType": "NATURAL",
@@ -21,7 +23,8 @@
         "Id": "1167497",
         "Tag": "",
         "CreationDate": 1382627263,
-        "KYCLevel": "REGULAR"
+        "KYCLevel": "REGULAR",
+        "FirstName": "Alex"
     },
     {
         "PersonType": "NATURAL",
@@ -29,7 +32,8 @@
         "Id": "1167498",
         "Tag": null,
         "CreationDate": 1383143870,
-        "KYCLevel": "LIGHT"
+        "KYCLevel": "LIGHT",
+        "FirstName": "Sarah"
     },
     {
         "PersonType": "NATURAL",
@@ -37,7 +41,8 @@
         "Id": "1167499",
         "Tag": null,
         "CreationDate": 1382605938,
-        "KYCLevel": "LIGHT"
+        "KYCLevel": "LIGHT",
+        "FirstName": "Florent"
     },
     {
         "PersonType": "LEGAL",
@@ -45,7 +50,8 @@
         "Id": "1167500",
         "Tag": null,
         "CreationDate": 1382607639,
-        "KYCLevel": "LIGHT"
+        "KYCLevel": "LIGHT",
+        "Name": "Tsilla Ltd"
     },
     {
         "PersonType": "NATURAL",
@@ -53,7 +59,8 @@
         "Id": "1167501",
         "Tag": "",
         "CreationDate": 1382627263,
-        "KYCLevel": "REGULAR"
+        "KYCLevel": "REGULAR",
+        "FirstName": "Annika"
     },
     {
         "PersonType": "NATURAL",
@@ -61,7 +68,8 @@
         "Id": "1167502",
         "Tag": null,
         "CreationDate": 1383143870,
-        "KYCLevel": "LIGHT"
+        "KYCLevel": "LIGHT",
+        "FirstName": "Margaux"
     },
     {
         "PersonType": "NATURAL",
@@ -69,7 +77,8 @@
         "Id": "1167503",
         "Tag": null,
         "CreationDate": 1382605938,
-        "KYCLevel": "LIGHT"
+        "KYCLevel": "LIGHT",
+        "FirstName": "Adele"
     },
     {
         "PersonType": "LEGAL",
@@ -77,6 +86,7 @@
         "Id": "1167504",
         "Tag": null,
         "CreationDate": 1382607639,
-        "KYCLevel": "LIGHT"
+        "KYCLevel": "LIGHT",
+        "Name": "Shana Co"
     }
 ]

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -3,10 +3,10 @@ from datetime import datetime
 
 from tests import settings
 from tests.mocks import get_fixture
-from .mocks import today, today_timestamp
-from .resources import (User, NaturalUser, Wallet,
+from tests.mocks import today, today_timestamp
+from mangopay.resources import (User, NaturalUser, Wallet,
                                 LegalUser, Transfer, Transaction, UboDeclaration)
-from .test_base import BaseTest, BaseTestLive
+from tests.test_base import BaseTest, BaseTestLive
 
 from mangopay.utils import Money, Address, DeclaredUbo
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -2,10 +2,10 @@
 from datetime import datetime
 
 from tests import settings
-from .mocks import today, today_timestamp
-from .resources import (User, NaturalUser, Wallet,
-                        LegalUser, Transfer, Transaction)
-from .test_base import BaseTest, BaseTestLive
+from tests.mocks import today, today_timestamp
+from mangopay.resources import (User, NaturalUser, Wallet,
+                                LegalUser, Transfer, Transaction)
+from tests.test_base import BaseTest, BaseTestLive
 
 from mangopay.utils import Money, Address
 
@@ -24,7 +24,8 @@ class UsersTest(BaseTest):
 
         self.register_mock({
             "method": responses.PUT,
-            "url": re.compile(r''+settings.MANGOPAY_API_SANDBOX_URL+settings.MANGOPAY_CLIENT_ID+'/users/natural/\d+'),
+            "url": re.compile(
+                r'' + settings.MANGOPAY_API_SANDBOX_URL + settings.MANGOPAY_CLIENT_ID + '/users/natural/\d+'),
             "body": {
                 "FirstName": "Victor",
                 "LastName": "Claver",
@@ -94,7 +95,8 @@ class UsersTest(BaseTest):
 
         self.register_mock({
             'method': responses.PUT,
-            'url': re.compile(r''+settings.MANGOPAY_API_SANDBOX_URL+settings.MANGOPAY_CLIENT_ID+'/users/legal/\d+'),
+            'url': re.compile(
+                r'' + settings.MANGOPAY_API_SANDBOX_URL + settings.MANGOPAY_CLIENT_ID + '/users/legal/\d+'),
             'body': {
                 "Name": "MangoPay edited",
                 "LegalPersonType": "BUSINESS",
@@ -170,7 +172,7 @@ class UsersTest(BaseTest):
         self.register_mock([
             {
                 'method': responses.GET,
-                'url': settings.MANGOPAY_API_SANDBOX_URL+settings.MANGOPAY_CLIENT_ID+'/users/natural/1169419',
+                'url': settings.MANGOPAY_API_SANDBOX_URL + settings.MANGOPAY_CLIENT_ID + '/users/natural/1169419',
                 'body': {
                     "FirstName": "Victor",
                     "LastName": "Hugo",
@@ -200,7 +202,7 @@ class UsersTest(BaseTest):
             },
             {
                 'method': responses.GET,
-                'url': settings.MANGOPAY_API_SANDBOX_URL+settings.MANGOPAY_CLIENT_ID+'/users/natural/1169420',
+                'url': settings.MANGOPAY_API_SANDBOX_URL + settings.MANGOPAY_CLIENT_ID + '/users/natural/1169420',
                 'body': {"errors": []},
                 'status': 404
             }])
@@ -243,7 +245,7 @@ class UsersTest(BaseTest):
         self.register_mock([
             {
                 'method': responses.GET,
-                'url': settings.MANGOPAY_API_SANDBOX_URL+settings.MANGOPAY_CLIENT_ID+'/users/legal/1169420',
+                'url': settings.MANGOPAY_API_SANDBOX_URL + settings.MANGOPAY_CLIENT_ID + '/users/legal/1169420',
                 'body': {
                     "Name": "MangoPay",
                     "LegalPersonType": "BUSINESS",
@@ -276,7 +278,7 @@ class UsersTest(BaseTest):
             },
             {
                 'method': responses.GET,
-                'url': settings.MANGOPAY_API_SANDBOX_URL+settings.MANGOPAY_CLIENT_ID+'/users/legal/1169421',
+                'url': settings.MANGOPAY_API_SANDBOX_URL + settings.MANGOPAY_CLIENT_ID + '/users/legal/1169421',
                 'body': {"errors": []},
                 'status': 404
             }])
@@ -320,7 +322,7 @@ class UsersTest(BaseTest):
     def test_retrieve_all_users(self):
         self.register_mock({
             'method': responses.GET,
-            'url': settings.MANGOPAY_API_SANDBOX_URL+settings.MANGOPAY_CLIENT_ID+'/users',
+            'url': settings.MANGOPAY_API_SANDBOX_URL + settings.MANGOPAY_CLIENT_ID + '/users',
             'body': [
                 {
                     "PersonType": "NATURAL",
@@ -376,6 +378,12 @@ class UsersTest(BaseTest):
 
         users = User.all()
         self.assertEqual(len(users), 10)
+        for user in users:
+            if isinstance(user, NaturalUser):
+                self.assertIsNotNone(user.first_name)
+            else:
+                self.assertIsInstance(user, LegalUser)
+                self.assertIsNotNone(user.name)
 
         users = User.all(page=1, per_page=2)
         self.assertEqual(len(users), 2)
@@ -401,7 +409,7 @@ class UsersTest(BaseTest):
 
         self.register_mock({
             'method': responses.GET,
-            'url': re.compile(r''+settings.MANGOPAY_API_SANDBOX_URL+settings.MANGOPAY_CLIENT_ID+'/users/\d+'),
+            'url': re.compile(r'' + settings.MANGOPAY_API_SANDBOX_URL + settings.MANGOPAY_CLIENT_ID + '/users/\d+'),
             'body': {
                 "FirstName": "Victor",
                 "LastName": "Hugo",
@@ -464,7 +472,7 @@ class UsersTest(BaseTest):
 
         self.register_mock({
             'method': responses.GET,
-            'url': re.compile(r''+settings.MANGOPAY_API_SANDBOX_URL+settings.MANGOPAY_CLIENT_ID+'/users/\d+'),
+            'url': re.compile(r'' + settings.MANGOPAY_API_SANDBOX_URL + settings.MANGOPAY_CLIENT_ID + '/users/\d+'),
             'body': {
                 "Name": "MangoPay",
                 "LegalPersonType": "BUSINESS",
@@ -543,7 +551,7 @@ class UsersTest(BaseTest):
         self.register_mock([
             {
                 'method': responses.GET,
-                'url': settings.MANGOPAY_API_SANDBOX_URL+settings.MANGOPAY_CLIENT_ID+'/users/1167495',
+                'url': settings.MANGOPAY_API_SANDBOX_URL + settings.MANGOPAY_CLIENT_ID + '/users/1167495',
                 'body': {
                     "FirstName": "Victor",
                     "LastName": "Hugo",
@@ -573,7 +581,7 @@ class UsersTest(BaseTest):
             },
             {
                 'method': responses.POST,
-                'url': settings.MANGOPAY_API_SANDBOX_URL+settings.MANGOPAY_CLIENT_ID+'/transfers',
+                'url': settings.MANGOPAY_API_SANDBOX_URL + settings.MANGOPAY_CLIENT_ID + '/transfers',
                 'body': {
                     "Id": "1169434",
                     "Tag": "DefaultTag",
@@ -605,7 +613,7 @@ class UsersTest(BaseTest):
             },
             {
                 'method': responses.GET,
-                'url': settings.MANGOPAY_API_SANDBOX_URL+settings.MANGOPAY_CLIENT_ID+'/users/1169419/transactions',
+                'url': settings.MANGOPAY_API_SANDBOX_URL + settings.MANGOPAY_CLIENT_ID + '/users/1169419/transactions',
                 'body': [
                     {
                         "Id": "1174837",
@@ -669,7 +677,6 @@ class UsersTest(BaseTest):
 
 
 class UserTestLive(BaseTestLive):
-
     def test_Users_GetKycDocuments(self):
         user = BaseTestLive.get_john()
         BaseTestLive.get_johns_kyc_document()

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -328,7 +328,8 @@ class UsersTest(BaseTest):
                     "Id": "1167495",
                     "Tag": None,
                     "CreationDate": 1382605938,
-                    "KYCLevel": "LIGHT"
+                    "KYCLevel": "LIGHT",
+                    "FirstName": "Victor"
                 },
                 {
                     "PersonType": "LEGAL",
@@ -363,6 +364,7 @@ class UsersTest(BaseTest):
 
         self.assertIsInstance(users[0], NaturalUser)
         self.assertEqual(users[0].email, 'victor@hugo.com')
+        self.assertIsNotNone(users[0].first_name)
 
     @responses.activate
     def test_retrieve_paginated_users(self):


### PR DESCRIPTION
Found the issue concerning incorrect de-serialization, specifically because of a type parameter not being sent to the deserialization method, so the method sometimes did not know exactly which type of object it was deserializing - this was outlined in Gabriel's test where he checked for the existence of FirstName field in the mock response. The test is now passing.
As well, there is now a check for both Legal and Natural users in the Get All Users mock test, so that it is more clear how the problem is now gone.

Issue: https://github.com/Mangopay/mangopay2-python-sdk/issues/111