### PR TITLE
Implemented Get Refunds for a PayOut endpoint.

### DIFF
--- a/mangopay/resources.py
+++ b/mangopay/resources.py
@@ -667,6 +667,12 @@ class BankWirePayOut(BaseModel):
     bank_wire_ref = CharField(api_name='BankWireRef')
     credited_user = ForeignKeyField(User, api_name='CreditedUserId')
 
+    def get_refunds(self, *args, **kwargs):
+        kwargs['id'] = self.id
+        select = SelectQuery(Refund, *args, **kwargs)
+        select.identifier = 'PAYOUT_GET_REFUNDS'
+        return select.all(*args, **kwargs)
+
     class Meta:
         verbose_name = 'payout'
         verbose_name_plural = 'payouts'
@@ -701,7 +707,12 @@ class Refund(BaseModel):
     class Meta:
         verbose_name = 'refund'
         verbose_name_plural = 'refunds'
-        url = '/refunds'
+        url = {
+            SelectQuery.identifier: '/refunds',
+            InsertQuery.identifier: '/refunds',
+            UpdateQuery.identifier: '/refunds',
+            'PAYOUT_GET_REFUNDS': '/payouts/%(id)s/refunds'
+        }
 
 
 @python_2_unicode_compatible

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -8,7 +8,7 @@ from mangopay.utils import Address, ReportTransactionsFilters
 from . import settings
 from .mocks import RegisteredMocks
 from .resources import (NaturalUser, LegalUser, Wallet,
-                        CardRegistration, Card)
+                        CardRegistration, Card, BankWirePayOut, Money)
 
 import responses
 import time
@@ -197,6 +197,7 @@ class BaseTestLive(unittest.TestCase):
     _johns_kyc_document = None
     _oauth_manager = AuthorizationTokenManager(get_default_handler(), StaticStorageStrategy())
     _johns_report = None
+    _johns_payout = None
 
     def setUp(self):
         BaseTestLive.get_john()
@@ -261,6 +262,26 @@ class BaseTestLive(unittest.TestCase):
             wallet.description = 'WALLET IN EUR'
             BaseTestLive._johns_wallet = Wallet(**wallet.save())
         return BaseTestLive._johns_wallet
+
+    @staticmethod
+    def get_johns_payout(recreate=False):
+        if BaseTestLive._johns_payout is None or recreate:
+            john = BaseTestLive.get_john()
+            wallet = BaseTestLive.get_johns_wallet()
+            account = BaseTestLive.get_johns_account()
+
+            payout = BankWirePayOut()
+            payout.debited_wallet = wallet
+            payout.author = john
+            payout.credited_user = john
+            payout.tag = 'DefaultTag'
+            payout.debited_funds = Money(amount=10, currency='EUR')
+            payout.fees = Money(amount=5, currency='EUR')
+            payout.bank_account = account
+            payout.bank_wire_ref = 'User payment'
+            payout.payment_type = 'BANK_WIRE'
+            BaseTestLive._johns_payout = BankWirePayOut(**payout.save())
+        return BaseTestLive._johns_payout
 
     @staticmethod
     def get_oauth_manager():

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -776,3 +776,14 @@ class UserTestLive(BaseTestLive):
         documents = user.documents.all()
 
         self.assertTrue(documents)
+
+
+class PayOutsTestLive(BaseTestLive):
+
+    def test_PayOut_GetRefunds(self):
+        payout = BaseTestLive.get_johns_payout()
+
+        refunds = payout.get_refunds()
+
+        self.assertIsNotNone(refunds)
+        self.assertIsInstance(refunds, list)


### PR DESCRIPTION
Placed the test in the test_users suite because for some reason an 'invalid_credentials' error is thrown when it is run from either test_payouts or test_refunds.