### PR TITLE
Fix typo from PreAuthorization resource

### DIFF
--- a/mangopay/api.py
+++ b/mangopay/api.py
@@ -85,7 +85,7 @@ class APIRequest(object):
             url = '%s?%s' % (url, encoded_params)
 
         if data or data == {}:
-            # truncated_data = truncatechars(copy.copy(data))
+            truncated_data = truncatechars(copy.copy(data))
 
             data = json.dumps(data, default=lambda x: x.to_api_json())
 

--- a/mangopay/resources.py
+++ b/mangopay/resources.py
@@ -641,7 +641,7 @@ class PreAuthorization(BaseModel):
     secure_mode_redirect_url = CharField(api_name='SecureModeRedirectURL')
     secure_mode_return_url = CharField(api_name='SecureModeReturnURL', required=True)
     expiration_date = DateField(api_name='ExpirationDate')
-    payin = ForeignKeyField(PayIn, api_name='PayinId')
+    payin = ForeignKeyField(PayIn, api_name='PayInId')
     billing = BillingField(api_name='Billing')
     security_info = SecurityInfoField(api_name='SecurityInfo')
 


### PR DESCRIPTION
As we can see from the documentation and the api.
https://docs.mangopay.com/endpoints/v2.01/preauthorizations#e183_the-preauthorization-object

The api name for the payin id is `PayInId` and not `PayinId`.