### PR TITLE
Improve logging calls.

### DIFF
--- a/mangopay/api.py
+++ b/mangopay/api.py
@@ -103,7 +103,7 @@ class APIRequest(object):
 
             data = json.dumps(data, default=lambda x: x.to_api_json())
 
-        logger.debug('DATA[IN -> %s]\n\t- headers: %s\n\t- content: %s' % (url, headers, truncated_data))
+        logger.debug('DATA[IN -> %s]\n\t- headers: %s\n\t- content: %s', url, headers, truncated_data)
 
         ts = time.time()
 
@@ -145,12 +145,12 @@ class APIRequest(object):
                               result=result,
                               laps=laps)
 
-        logger.debug('DATA[OUT -> %s][%2.3f seconds]\n\t- status_code: %s\n\t- headers: %s\n\t- content: %s' % (
+        logger.debug('DATA[OUT -> %s][%2.3f seconds]\n\t- status_code: %s\n\t- headers: %s\n\t- content: %s',
             url,
             laps,
             result.status_code,
             result.headers,
-            result.text if hasattr(result, 'text') else result.content)
+            result.text if hasattr(result, 'text') else result.content
         )
 
         self.read_response_headers(result.headers)
@@ -234,14 +234,14 @@ class APIRequest(object):
 
         headers = result.headers
 
-        logger.error('API ERROR: status_code: %s | url: %s | method: %s | data: %r | headers: %s | content: %s' % (
+        logger.error('API ERROR: status_code: %s | url: %s | method: %s | data: %r | headers: %s | content: %s',
             status_code,
             url,
             method,
             data,
             headers,
-            text
-        ))
+            text,
+        )
 
         request_error.send(url=url, status_code=status_code, headers=headers)
 
@@ -260,9 +260,11 @@ class APIRequest(object):
 
         headers = result.headers
 
-        logger.error('DECODE ERROR: status_code: %s | headers: %s | content: %s' % (status_code,
-                                                                                    headers,
-                                                                                    text))
+        logger.error('DECODE ERROR: status_code: %s | headers: %s | content: %s',
+            status_code,
+            headers,
+            text,
+        )
 
         request_error.send(url=url, status_code=status_code, headers=headers)
 


### PR DESCRIPTION
The logging module expects user to provide the string as a first
argument, and all interpolation parameters in separate positional or
keyword arguments: `logger.debug("trying x=%s", x)`.

This brings two benefits:
- The interpolation is only performed if the logging message is actually
  used (debug messages won't even be interpolated if logging is set to
  WARNING)
- Monitoring libraries like Sentry can group messages based on their
  non-interpolated message, which helps detecting similar issues.

See:
- https://docs.python.org/3/howto/logging.html#logging-variable-data
- http://pylint.pycqa.org/en/latest/technical_reference/features.html#logging-checker-messages
  (W1201)

Signed-off-by: Raphaël Barrois <raphael.barrois@paylead.fr>