### PR TITLE
[release] 3.47.0

### DIFF
--- a/mangopay/constants.py
+++ b/mangopay/constants.py
@@ -352,6 +352,7 @@ PAYIN_PAYMENT_TYPE = Choices(
     ("IDEAL", "ideal", "Ideal"),
     ("GIROPAY", "giropay", "Giropay"),
     ("BCMC", "bancontact", "Bancontact"),
+    ("BIZUM", "bizum", "Bizum"),
     ("SWISH", "swish", "Swish"),
     ("TWINT", "twint", "Twint")
 )

--- a/mangopay/constants.py
+++ b/mangopay/constants.py
@@ -2,7 +2,8 @@ from .utils import Choices
 
 USER_TYPE_CHOICES = Choices(
     ('NATURAL', 'natural', 'Natural user'),
-    ('LEGAL', 'legal', 'Legal user')
+    ('LEGAL', 'legal', 'Legal user'),
+    ('PLATFORM', 'platform', 'Platform user')
 )
 
 LEGAL_USER_TYPE_CHOICES = Choices(
@@ -178,6 +179,10 @@ EVENT_TYPE_CHOICES = Choices(
     ('UBO_DECLARATION_INCOMPLETE', 'ubo_declaration_incomplete', 'Ubo Declaration Incomplete'),
     ('USER_KYC_LIGHT', 'user_kyc_light', 'User Kyc Light'),
 
+    ('SCA_ENROLLMENT_SUCCEEDED', 'sca_enrollment_succeeded', 'Sca enrollment succeeded'),
+    ('SCA_ENROLLMENT_FAILED', 'sca_enrollment_failed', 'Sca enrollment failed'),
+    ('SCA_ENROLLMENT_EXPIRED', 'sca_enrollment_expired', 'Sca enrollment expired'),
+
     ('VIRTUAL_ACCOUNT_ACTIVE', 'virtual_account_active', 'Virtual Account Active'),
     ('VIRTUAL_ACCOUNT_BLOCKED', 'virtual_account_blocked', 'Virtual Account Blocked'),
     ('VIRTUAL_ACCOUNT_CLOSED', 'virtual_account_closed', 'Virtual Account Closed'),
@@ -221,6 +226,10 @@ EVENT_TYPE_CHOICES = Choices(
     ('QUOTED_CONVERSION_CREATED', 'quoted_conversion_created', 'Quoted Conversion Created'),
     ('QUOTED_CONVERSION_SUCCEEDED', 'quoted_conversion_succeeded', 'Quoted Conversion Succeeded'),
     ('QUOTED_CONVERSION_FAILED', 'quoted_conversion_failed', 'Quoted Conversion Failed'),
+
+    ('USER_CATEGORY_UPDATED_TO_OWNER', 'user_category_updated_to_owner', 'User category updated to owner'),
+    ('USER_CATEGORY_UPDATED_TO_PAYER', 'user_category_updated_to_payer', 'User category updated to payer'),
+    ('USER_CATEGORY_UPDATED_TO_PLATFORM', 'user_category_updated_to_platform', 'User category updated to platform'),
 
     ('REPORT_GENERATED', 'report_generated', 'Report Generated'),
     ('REPORT_FAILED', 'report_failed', 'Report Failed')

--- a/mangopay/resources.py
+++ b/mangopay/resources.py
@@ -820,6 +820,7 @@ class PayIn(BaseModel):
             ("IDEAL", "WEB"): IdealPayIn,
             ("GIROPAY", "WEB"): GiropayPayIn,
             ("BANCONTACT", "WEB"): BancontactPayIn,
+            ("BIZUM", "WEB"): BizumPayIn,
             ("SWISH", "WEB"): SwishPayIn,
         }
 
@@ -1467,6 +1468,26 @@ class BancontactPayIn(PayIn):
         verbose_name_plural = 'bancontact_payins'
         url = {
             InsertQuery.identifier: '/payins/payment-methods/bancontact',
+            SelectQuery.identifier: '/payins'
+        }
+
+
+class BizumPayIn(PayIn):
+    author = ForeignKeyField(User, api_name='AuthorId', required=True)
+    debited_funds = MoneyField(api_name='DebitedFunds', required=True)
+    fees = MoneyField(api_name='Fees', required=True)
+    credited_wallet = ForeignKeyField(Wallet, api_name='CreditedWalletId', required=True)
+    statement_descriptor = CharField(api_name='StatementDescriptor')
+    return_url = CharField(api_name='ReturnURL')
+    phone = CharField(api_name='Phone')
+    profiling_attempt_reference = CharField(api_name='ProfilingAttemptReference')
+    tag = CharField(api_name='Tag')
+
+    class Meta:
+        verbose_name = 'bizum_payin'
+        verbose_name_plural = 'bizum_payins'
+        url = {
+            InsertQuery.identifier: '/payins/payment-methods/bizum',
             SelectQuery.identifier: '/payins'
         }
 

--- a/mangopay/resources.py
+++ b/mangopay/resources.py
@@ -616,6 +616,13 @@ class Card(BaseModel):
         select.identifier = 'CARD_GET_TRANSACTIONS'
         return select.all(*args, **kwargs)
 
+    @classmethod
+    def get_transactions_by_fingerprint(cls, fingerprint, *args, **kwargs):
+        kwargs['fingerprint'] = fingerprint
+        select = SelectQuery(Transaction, *args, **kwargs)
+        select.identifier = 'TRANSACTIONS_FOR_FINGERPRINT'
+        return select.all(*args, **kwargs)
+
     class Meta:
         verbose_name = 'card'
         verbose_name_plural = 'cards'
@@ -2014,7 +2021,8 @@ class Transaction(BaseModel):
             'BANK_ACCOUNT_GET_TRANSACTIONS': '/bankaccounts/%(id)s/transactions',
             'PRE_AUTHORIZATION_TRANSACTIONS': '/preauthorizations/%(id)s/transactions',
             'CLIENT_WALLET_TRANSACTIONS': '/clients/wallets/%(fund_type)s/%(currency)s/transactions',
-            'DEPOSIT_GET_TRANSACTIONS': '/deposit-preauthorizations/%(deposit_id)s/transactions/'
+            'DEPOSIT_GET_TRANSACTIONS': '/deposit-preauthorizations/%(deposit_id)s/transactions/',
+            'TRANSACTIONS_FOR_FINGERPRINT': '/cards/fingerprints/%(fingerprint)s/transactions'
         }
 
     def __str__(self):

--- a/mangopay/resources.py
+++ b/mangopay/resources.py
@@ -2022,7 +2022,8 @@ class Transaction(BaseModel):
             'PRE_AUTHORIZATION_TRANSACTIONS': '/preauthorizations/%(id)s/transactions',
             'CLIENT_WALLET_TRANSACTIONS': '/clients/wallets/%(fund_type)s/%(currency)s/transactions',
             'DEPOSIT_GET_TRANSACTIONS': '/deposit-preauthorizations/%(deposit_id)s/transactions/',
-            'TRANSACTIONS_FOR_FINGERPRINT': '/cards/fingerprints/%(fingerprint)s/transactions'
+            'TRANSACTIONS_FOR_FINGERPRINT': '/cards/fingerprints/%(fingerprint)s/transactions',
+            'DISPUTE_GET_TRANSACTIONS': '/disputes/%(dispute_id)s/transactions/'
         }
 
     def __str__(self):
@@ -2195,6 +2196,13 @@ class Dispute(BaseModel):
     def get_pending_settlement(cls, *args, **kwargs):
         select = SelectQuery(cls, *args, **kwargs)
         select.identifier = 'PENDING_SETTLEMENT'
+        return select.all(*args, **kwargs)
+
+    @classmethod
+    def get_transactions(cls, dispute_id, *args, **kwargs):
+        kwargs['dispute_id'] = dispute_id
+        select = SelectQuery(Transaction, *args, **kwargs)
+        select.identifier = 'DISPUTE_GET_TRANSACTIONS'
         return select.all(*args, **kwargs)
 
 

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -357,3 +357,9 @@ class CardsLiveTest(BaseTestLive):
         self.assertIsNotNone(get_card_validation_response.data[0])
         self.assertIsNotNone(get_card_validation_response.data[0].id)
         self.assertEqual(get_card_validation_response.data[0].id, validation_response['id'])
+
+    def test_get_transactions_for_fingerprint(self):
+        card = BaseTestLive.get_johns_card()
+        time.sleep(2)
+        transactions_page = Card.get_transactions_by_fingerprint(card.fingerprint)
+        self.assertTrue(len(transactions_page) > 0)

--- a/tests/test_disputes.py
+++ b/tests/test_disputes.py
@@ -365,3 +365,18 @@ class DisputeTest(BaseTestLive):
         self.assertTrue('status' in result)
 
         self.assertEquals(result['status'], 'SUBMITTED')
+
+    def test_get_transactions(self):
+        dispute = None
+        for d in self._client_disputes:
+            if d.status in ('PENDING_CLIENT_ACTION', 'REOPENED_PENDING_CLIENT_ACTION'):
+                dispute = d
+                break
+
+        self.assertIsNotNone(
+            dispute,
+            "Cannot test closing dispute because there's no available disputes with expected status in the disputes list."
+        )
+
+        transactions = Dispute.get_transactions(dispute.id)
+        self.assertTrue(transactions.page == 1)

--- a/tests/test_payins.py
+++ b/tests/test_payins.py
@@ -8,7 +8,7 @@ from mangopay.resources import DirectDebitDirectPayIn, Mandate, ApplepayPayIn, G
     RecurringPayInRegistration, \
     RecurringPayInCIT, PayInRefund, RecurringPayInMIT, CardPreAuthorizedDepositPayIn, MbwayPayIn, PayPalWebPayIn, \
     GooglePayDirectPayIn, MultibancoPayIn, SatispayPayIn, BlikPayIn, KlarnaPayIn, IdealPayIn, GiropayPayIn, \
-    CardRegistration, BancontactPayIn, SwishPayIn, PayconiqV2PayIn, TwintPayIn, PayByBankPayIn, RecurringPayPalPayInCIT, \
+    CardRegistration, BancontactPayIn, BizumPayIn, SwishPayIn, PayconiqV2PayIn, TwintPayIn, PayByBankPayIn, RecurringPayPalPayInCIT, \
     RecurringPayPalPayInMIT
 from mangopay.utils import (Money, ShippingAddress, Shipping, Billing, Address, SecurityInfo, ApplepayPaymentData,
                             GooglepayPaymentData, DebitedBankAccount, LineItem, CardInfo)
@@ -1872,6 +1872,80 @@ class PayInsTestLive(BaseTestLive):
         self.assertEqual("REGULAR", result.nature)
         self.assertEqual("WEB", result.execution_type)
         self.assertEqual("BCMC", result.payment_type)
+        self.assertEqual("PAYIN", result.type)
+
+    def test_PayIns_BizumWeb_CreateWithPhone(self):
+        user = BaseTestLive.get_john(True)
+
+        # create wallet
+        credited_wallet = Wallet()
+        credited_wallet.owners = (user,)
+        credited_wallet.currency = 'EUR'
+        credited_wallet.description = 'WALLET IN EUR'
+        credited_wallet = Wallet(**credited_wallet.save())
+
+        pay_in = BizumPayIn()
+        pay_in.author = user
+        pay_in.credited_wallet = credited_wallet
+        pay_in.fees = Money()
+        pay_in.fees.amount = 200
+        pay_in.fees.currency = 'EUR'
+        pay_in.debited_funds = Money()
+        pay_in.debited_funds.amount = 2000
+        pay_in.debited_funds.currency = 'EUR'
+        pay_in.statement_descriptor = 'Example123'
+        pay_in.phone = '+34700000000'
+        pay_in.tag = 'Bizum PayIn'
+
+        result = BizumPayIn(**pay_in.save())
+        fetched = BizumPayIn().get(result.id)
+
+        self.assertIsNotNone(result)
+        self.assertIsNotNone(fetched)
+        self.assertEqual(result.id, fetched.id)
+        self.assertIsNotNone(result.phone)
+        self.assertIsNone(result.return_url)
+
+        self.assertEqual("CREATED", result.status)
+        self.assertEqual("WEB", result.execution_type)
+        self.assertEqual("BIZUM", result.payment_type)
+        self.assertEqual("PAYIN", result.type)
+
+    def test_PayIns_BizumWeb_CreateWithReturnUrl(self):
+        user = BaseTestLive.get_john(True)
+
+        # create wallet
+        credited_wallet = Wallet()
+        credited_wallet.owners = (user,)
+        credited_wallet.currency = 'EUR'
+        credited_wallet.description = 'WALLET IN EUR'
+        credited_wallet = Wallet(**credited_wallet.save())
+
+        pay_in = BizumPayIn()
+        pay_in.author = user
+        pay_in.credited_wallet = credited_wallet
+        pay_in.fees = Money()
+        pay_in.fees.amount = 200
+        pay_in.fees.currency = 'EUR'
+        pay_in.debited_funds = Money()
+        pay_in.debited_funds.amount = 2000
+        pay_in.debited_funds.currency = 'EUR'
+        pay_in.statement_descriptor = 'Example123'
+        pay_in.return_url = 'https://docs.mangopay.com/please-ignore'
+        pay_in.tag = 'Bizum PayIn'
+
+        result = BizumPayIn(**pay_in.save())
+        fetched = BizumPayIn().get(result.id)
+
+        self.assertIsNotNone(result)
+        self.assertIsNotNone(fetched)
+        self.assertEqual(result.id, fetched.id)
+        self.assertIsNone(result.phone)
+        self.assertIsNotNone(result.return_url)
+
+        self.assertEqual("CREATED", result.status)
+        self.assertEqual("WEB", result.execution_type)
+        self.assertEqual("BIZUM", result.payment_type)
         self.assertEqual("PAYIN", result.type)
 
     def test_PayIns_Legacy_IdealWeb_Create(self):


### PR DESCRIPTION
New endpoint POST Create a Bizum PayIn
New webhook event types for SCA enrollment (API release note), note that these are triggered on enrollment not authentication:
SCA_ENROLLMENT_SUCCEEDED
SCA_ENROLLMENT_FAILED
SCA_ENROLLMENT_EXPIRED
New webhook event types for UserCategory change (API release note )
USER_CATEGORY_UPDATED_TO_OWNER
USER_CATEGORY_UPDATED_TO_PAYER
USER_CATEGORY_UPDATED_TO_PLATFORM
Support for PLATFORM value to UserCategory enum
Support for GET List Transactions for a Card Fingerprint
Support for GET List Transactions for a Dispute